### PR TITLE
fix: Change the label of push down operation at the method level

### DIFF
--- a/src/main/java/apidiff/internal/analysis/MethodDiff.java
+++ b/src/main/java/apidiff/internal/analysis/MethodDiff.java
@@ -94,7 +94,7 @@ public class MethodDiff {
 				category = Category.METHOD_MOVE;
 				break;
 	
-			case PUSH_DOWN_ATTRIBUTE:
+			case PUSH_DOWN_OPERATION:
 				category = Category.METHOD_PUSH_DOWN;
 				break;
 				


### PR DESCRIPTION
## Comment
- I found that APIDIFF mistakenly detects push down method as  pull up method. I try to fix it and could you please kindly confirm that is okay or not ? 

## Issue
- APIDIFF mistakenly detects push down method as  pull up method.

## Content
- Fix Bug
    - Change Case Label in method getCategory(RefactoringType refactoringType) in class MethodDiff.

## Operation Check
- Target Project:[PHILJAY/MPANDROIDCHART](https://github.com/PhilJay/MPAndroidChart/commit/f36ba8de48ecc748a498d87595597edfb7abb0e8)
- Target Commit:f36ba8de48ecc748a498d87595597edfb7abb0e8
- Description of Push Down Method

```
<br> Push Down method <code>getVals()</code><br>from <code>com.github.mikephil.charting.data.Entry</code><br>to <code>com.github.mikephil.charting.data.BarEntry</code><br>

<br> Push Down method <code>setVals(float[])</code><br>from <code>com.github.mikephil.charting.data.Entry</code><br>to <code>com.github.mikephil.charting.data.BarEntry</code><br>

<br> Push Down method <code>getClosestIndexAbove(float)</code><br>from <code>com.github.mikephil.charting.data.Entry</code><br>to <code>com.github.mikephil.charting.data.BarEntry</code><br>
```